### PR TITLE
Fix updated_timestamp partition ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_twitter_source v0.4.1
+- Fixes the `is_latest_version` flag to correctly identify the last updated row.
+
 # dbt_twitter_source v0.4.0
 🎉 dbt v1.0.0 Compatibility 🎉
 ## 🚨 Breaking Changes 🚨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dbt_twitter_source v0.4.1
-- Fixes the `is_latest_version` flag to correctly identify the last updated row.
+## Fixes
+- Changes the partition order for the following models so that the `is_latest_version` flag identifies the last updated row.
+  - models/stg_twitter_ads__account_history.sql
+  - models/stg_twitter_ads__campaign_history.sql
+  - models/stg_twitter_ads__line_item_history.sql
+  - models/stg_twitter_ads__promoted_tweet_history.sql
+## Contributors
+- [@dlubawy](https://github.com/dlubawy) ([#15](https://github.com/fivetran/dbt_twitter_source/pull/15))
 
 # dbt_twitter_source v0.4.0
 🎉 dbt v1.0.0 Compatibility 🎉

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'twitter_ads_source'
-version: '0.4.0'
+version: '0.4.1'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 models:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'twitter_source_integration_tests'
-version: '0.3.0'
+version: '0.3.1'
 profile: 'integration_tests'
 config-version: 2
 snapshot-paths: ["snapshots"]

--- a/models/stg_twitter_ads__account_history.sql
+++ b/models/stg_twitter_ads__account_history.sql
@@ -22,7 +22,7 @@ renamed as (
 
     select
         *,
-        row_number() over (partition by account_id order by updated_timestamp asc) = 1 as is_latest_version
+        row_number() over (partition by account_id order by updated_timestamp desc) = 1 as is_latest_version
     from renamed 
 
 )

--- a/models/stg_twitter_ads__campaign_history.sql
+++ b/models/stg_twitter_ads__campaign_history.sql
@@ -22,7 +22,7 @@ renamed as (
 
     select
         *,
-        row_number() over (partition by campaign_id order by updated_timestamp asc) = 1 as is_latest_version
+        row_number() over (partition by campaign_id order by updated_timestamp desc) = 1 as is_latest_version
     from renamed 
 
 )

--- a/models/stg_twitter_ads__line_item_history.sql
+++ b/models/stg_twitter_ads__line_item_history.sql
@@ -22,7 +22,7 @@ renamed as (
 
     select
         *,
-        row_number() over (partition by line_item_id order by updated_timestamp asc) = 1 as is_latest_version
+        row_number() over (partition by line_item_id order by updated_timestamp desc) = 1 as is_latest_version
     from renamed 
 
 )

--- a/models/stg_twitter_ads__promoted_tweet_history.sql
+++ b/models/stg_twitter_ads__promoted_tweet_history.sql
@@ -22,7 +22,7 @@ renamed as (
 
     select
         *,
-        row_number() over (partition by promoted_tweet_id order by updated_timestamp asc) = 1 as is_latest_version
+        row_number() over (partition by promoted_tweet_id order by updated_timestamp desc) = 1 as is_latest_version
     from renamed 
 
 )


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
Yes. Andrew Lubawy, Data Engineer at Cue Health.

**What change(s) does this PR introduce?** 
Bugfix: Fixes an issue with the `is_latest_version` column flag showing the oldest updated row.

**Did you update the CHANGELOG?** 
- [x] Yes

**Does this PR introduce a breaking change?**
- [x] Yes (please provide breaking change details below.)
Users may need to run a `--full-refresh` if they use incremental updates.
- [ ] No  (please provide an explanation as to how the change is non-breaking below.)

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
- [ ] Yes

**Is this PR in response to a previously created Bug or Feature Request**
- [x] Yes, Issue/Feature https://github.com/fivetran/dbt_twitter_source/issues/14
- [ ] No 

**How did you test the PR changes?** 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)
Checked in BigQuery whether the flag would be set correctly for the last updated timestamp.

**Select which warehouse(s) were used to test the PR**
- [x] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
🌞 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
